### PR TITLE
Add tutorial for writing a backend datasource

### DIFF
--- a/content/tutorials/build-a-data-source-backend-plugin.md
+++ b/content/tutorials/build-a-data-source-backend-plugin.md
@@ -62,12 +62,12 @@ yarn install --pure-lockfile
 
 The folders and files used to build the backend for the data source are
 
-| file/folder         | description                                                                                                                                         |
-| ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| file/folder         | description                                                                                                                                        |
+| ------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `Magefile.go`       | It’s not a requirement to use mage build files, but we strongly recommend using it so that you can use the build steps provided in the plugin SDK. |
-| `/src/plugins.json` | A JSON file describing the backend plugin                                                                                                           |
-| `/pkg/plugin.go`    | Starting point of the plugin binary. We suggest that you keep this small and have all data source code in another package                           |
-| `/pkg/datasource`   | The data source implementation in the plugin.                                                                                                       |
+| `/src/plugins.json` | A JSON file describing the backend plugin                                                                                                          |
+| `/pkg/plugin.go`    | Starting point of the plugin binary. We suggest that you keep this small and have all data source code in another package                          |
+| `/pkg/datasource`   | The data source implementation in the plugin.                                                                                                      |
 
 #### plugin.json
 
@@ -76,8 +76,8 @@ When building a backend plugin these fields are important:
 | field      | description                                                                                                            |
 | ---------- | ---------------------------------------------------------------------------------------------------------------------- |
 | backend    | Should be set to `true` for backend plugins. This tells Grafana that it should start a binary when loading the plugin. |
-| executable | This is the name of the executable that Grafana expects to start.                                                           |
-| alerting   | Should be set to true if your backend datasource supports alerting.                                                     |
+| executable | This is the name of the executable that Grafana expects to start.                                                      |
+| alerting   | Should be set to true if your backend datasource supports alerting.                                                    |
 
 #### /pkg/plugins.go
 
@@ -87,12 +87,7 @@ In this tutorial we are building a backend for a datasource, so we will provide 
 More about that in the next step!
 
 {{< /tutorials/step >}}
-{{< tutorials/step duration="1" title="Manage Data Source Configuration" >}}
-
-explain life cycle management for data sources.
-
-{{< /tutorials/step >}}
-{{< tutorials/step duration="2" title="Data Source Backend Plugins" >}}
+{{< tutorials/step duration="2" title="Data source backend plugins" >}}
 
 We begin by opening the file `/pkg/datasource/sample-datasource.go`. In this file you will see the `DatasourceInstance` struct which implements the `backend.QueryDataHandler` interface.
 The `QueryData` function on this struct is where the data fetching happens for a data source plugin.

--- a/content/tutorials/build-a-data-source-backend-plugin.md
+++ b/content/tutorials/build-a-data-source-backend-plugin.md
@@ -71,50 +71,50 @@ The folders and files used to build the backend for the data source are
 
 #### plugin.json
 
-When building a backend plugin these fields are important.
+When building a backend plugin these fields are important:
 
 | field      | description                                                                                                            |
 | ---------- | ---------------------------------------------------------------------------------------------------------------------- |
-| backend    | should be set to `true` for backend plugins. This tells Grafana that it should start a binary when loading the plugin. |
-| executable | is the name of the executable that grafana expects to start                                                            |
-| alerting   | Should be set to true if your backend datasource supports alerting                                                     |
+| backend    | Should be set to `true` for backend plugins. This tells Grafana that it should start a binary when loading the plugin. |
+| executable | This is the name of the executable that Grafana expects to start.                                                           |
+| alerting   | Should be set to true if your backend datasource supports alerting.                                                     |
 
 #### /pkg/plugins.go
 
-This is file where you provide the backend SDK with handler functions by calling `backend.Serve({})`. <!-- TODO update serve function with new PR is merged -->
-In this tutorial we are building a backend for a datasource so we will provide an implementation of the `backend.QueryDataHandler` interface.
+This is the file where you provide the backend SDK with handler functions by calling `backend.Serve({})`. <!-- TODO update serve function with new PR is merged -->
+In this tutorial we are building a backend for a datasource, so we will provide an example implementation of the `backend.QueryDataHandler` interface.
 
 More about that in the next step!
 
 {{< /tutorials/step >}}
-{{< tutorials/step duration="1" title="Manage data source configuration" >}}
+{{< tutorials/step duration="1" title="Manage Data Source Configuration" >}}
 
 explain life cycle management for data sources.
 
 {{< /tutorials/step >}}
-{{< tutorials/step duration="2" title="Data source backend plugins" >}}
+{{< tutorials/step duration="2" title="Data Source Backend Plugins" >}}
 
-Open the file `/pkg/datasource/sample-datasource.go` and you will see the `DatasourceInstance` struct which implements the `backend.QueryDataHandler` interface.
-The `QueryData` function on this struct is where the data fetching happens for data source plugin.
+We begin by opening the file `/pkg/datasource/sample-datasource.go`. In this file you will see the `DatasourceInstance` struct which implements the `backend.QueryDataHandler` interface.
+The `QueryData` function on this struct is where the data fetching happens for a data source plugin.
 
 Each request contains multiple queries to reduce traffic between Grafana and plugins.
-So you need to loop over the slice of queries, process each query and return the results of all queries.
+So you need to loop over the slice of queries, process each query, and then return the results of all queries.
 
 In the tutorial we have extract a function named `query` to take care of each query model.
-Since each plugin have their own unique query model, Grafana sends it to the backend plugin as JSON. Therefore the plugin needs
-to Unmarshal the query model into something easier to work with.
+Since each plugin has their own unique query model, Grafana sends it to the backend plugin as JSON. Therefore the plugin needs
+to `Unmarshal` the query model into something easier to work with.
 
-As you can see the sample only returns static numbers. Try to extend the plugin to return other types of data.
+You might have noticed that the sample only returns static numbers. Try to extend the plugin to return other types of data.
 You can read more about how to (build data frames in our docs)[https://grafana.com/docs/grafana/latest/plugins/developing/dataframes].
 
 {{< /tutorials/step >}}
-{{< tutorials/step duration="1" title="Add support for health checks" >}}
+{{< tutorials/step duration="1" title="Add Support for Health Checks" >}}
 
-Implementing the health check handler allows Grafana to verify that a data source have been configured correctly.
-After a user have created a new datasource in Grafanas UI she can click the **Test** to verify that it works as expected.
+Implementing the health check handler allows Grafana to verify that a data source has been configured correctly.
+After a user has created a new datasource in Grafana's UI, she can click the **Test** to verify that it works as expected.
 
-In this sample datasource there is a 50/50% chance that the health check is successful. Make sure to return good error messages to
-the users, informing them about what is miss configured in the data source.
+In this sample data source, there is a 50% chance that the health check will be successful. Make sure to return appropriate error messages to
+the users, informing them about what is misconfigured in the data source.
 
 Open `/pkg/datasource/sample-datasource.go` and navigate to the `CheckHealth` function to see how the health check for this sample plugin is implemented.
 

--- a/content/tutorials/build-a-data-source-backend-plugin.md
+++ b/content/tutorials/build-a-data-source-backend-plugin.md
@@ -43,7 +43,7 @@ The easiest way to get started is to clone one of our test data datasources. Nav
 npx @grafana/toolkit plugin:create my-plugin
 ```
 
-select `Backend Datasource Plugin` and follow the rest of the guide.
+select `Backend Datasource Plugin` and follow the rest of the steps in the plugin scaffolding command.
 
 ```
 cd my-plugin

--- a/content/tutorials/build-a-data-source-backend-plugin.md
+++ b/content/tutorials/build-a-data-source-backend-plugin.md
@@ -87,7 +87,7 @@ In this tutorial we are building a backend for a datasource, so we will provide 
 More about that in the next step!
 
 {{< /tutorials/step >}}
-{{< tutorials/step duration="2" title="Data source backend plugins" >}}
+{{< tutorials/step duration="2" title="Implement data queries" >}}
 
 We begin by opening the file `/pkg/datasource/sample-datasource.go`. In this file you will see the `DatasourceInstance` struct which implements the `backend.QueryDataHandler` interface.
 The `QueryData` function on this struct is where the data fetching happens for a data source plugin.
@@ -99,8 +99,8 @@ In the tutorial we have extract a function named `query` to take care of each qu
 Since each plugin has their own unique query model, Grafana sends it to the backend plugin as JSON. Therefore the plugin needs
 to `Unmarshal` the query model into something easier to work with.
 
-You might have noticed that the sample only returns static numbers. Try to extend the plugin to return other types of data.
-You can read more about how to (build data frames in our docs)[https://grafana.com/docs/grafana/latest/plugins/developing/dataframes].
+As you can see the sample only returns static numbers. Try to extend the plugin to return other types of data.
+You can read more about how to [build data frames in our docs](https://grafana.com/docs/grafana/latest/plugins/developing/dataframes).
 
 {{< /tutorials/step >}}
 {{< tutorials/step duration="1" title="Add Support for Health Checks" >}}

--- a/content/tutorials/build-a-data-source-backend-plugin.md
+++ b/content/tutorials/build-a-data-source-backend-plugin.md
@@ -64,7 +64,7 @@ The folders and files used to build the backend for the data source are
 
 | file/folder         | description                                                                                                                                         |
 | ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `Magefile.go`       | It’s not a requirement to use mage build files but we strongly recommend using that so that you can use the build steps provided in the plugin SDK. |
+| `Magefile.go`       | It’s not a requirement to use mage build files, but we strongly recommend using it so that you can use the build steps provided in the plugin SDK. |
 | `/src/plugins.json` | A JSON file describing the backend plugin                                                                                                           |
 | `/pkg/plugin.go`    | Starting point of the plugin binary. We suggest that you keep this small and have all data source code in another package                           |
 | `/pkg/datasource`   | The data source implementation in the plugin.                                                                                                       |

--- a/content/tutorials/build-a-data-source-backend-plugin.md
+++ b/content/tutorials/build-a-data-source-backend-plugin.md
@@ -17,12 +17,12 @@ Grafana supports a wide range of data sources, including Prometheus, MySQL, and 
 In this tutorial, you'll:
 
 - Build a backend for your data source
-- Implement an health check for your data source
+- Implement a health check for your data source
 - Enable alerting for your data source
 
 ### Prerequisites
 
-- Knowledge about how data source are implemented in the frontend.
+- Knowledge about how data sources are implemented in the frontend.
 - Grafana version 7.0+
 - Go 1.14+
 - [Mage](https://magefile.org/)
@@ -49,7 +49,7 @@ select `Backend Datasource Plugin` and follow the rest of the steps in the plugi
 cd my-plugin
 ```
 
-To build the plugin
+To build the plugin:
 
 ```
 yarn install --pure-lockfile
@@ -84,12 +84,12 @@ In the next step we will look at the query endpoint!
 {{< tutorials/step duration="2" title="Implement data queries" >}}
 
 We begin by opening the file `/pkg/datasource/sample-datasource.go`. In this file you will see the `DatasourceInstance` struct which implements the `backend.QueryDataHandler` interface.
-The `QueryData` function on this struct is where the data fetching happens for a data source plugin.
+The `QueryData` method on this struct is where the data fetching happens for a data source plugin.
 
 Each request contains multiple queries to reduce traffic between Grafana and plugins.
 So you need to loop over the slice of queries, process each query, and then return the results of all queries.
 
-In the tutorial we have extract a function named `query` to take care of each query model.
+In the tutorial we have extracted a function named `query` to take care of each query model.
 Since each plugin has their own unique query model, Grafana sends it to the backend plugin as JSON. Therefore the plugin needs
 to `Unmarshal` the query model into something easier to work with.
 

--- a/content/tutorials/build-a-data-source-backend-plugin.md
+++ b/content/tutorials/build-a-data-source-backend-plugin.md
@@ -1,0 +1,134 @@
+---
+title: Build a backend for a data source plugin
+summary: Create a backend for your data source plugin.
+id: build-a-data-source-backend-plugin
+categories: ["plugins"]
+tags: beginner
+status: Published
+authors: Grafana Labs
+Feedback Link: https://github.com/grafana/tutorials/issues/new
+weight: 70
+---
+
+{{% tutorials/step duration="1" title="Introduction" %}}
+
+Grafana supports a wide range of data sources, including Prometheus, MySQL, and even Datadog. There's a good chance you can already visualize metrics from the systems you have set up. In some cases, though, you already have an in-house metrics solution that you’d like to add to your Grafana dashboards. This tutorial teaches you to build a support for your data source.
+
+In this tutorial, you'll:
+
+- Build a backend for your data source
+- Implement an health check for your data source
+- Enable alerting for your data source
+
+### Prerequisites
+
+- Knowledge about how data source are implemented in the frontend.
+- Grafana version 7.0+
+- Go 1.14+
+- [Mage](https://magefile.org/)
+
+{{% /tutorials/step %}}
+{{% tutorials/step duration="1" title="Set up your environment" %}}
+
+{{< tutorials/shared "set-up-environment" >}}
+
+{{% /tutorials/step %}}
+{{% tutorials/step duration="1" title="Create a new plugin" %}}
+
+<!-- {{< tutorials/shared "create-plugin" >}} -->
+
+To build a backend for your data source plugin grafana requires binary that Grafana can execute when it loads plugin during start-up. In this guide, we will build a binary using our backend plugin SDK in Go.
+
+The easiest way to get started is to clone one of our test data datasources. Navigate to the plugin folder that you configured in step 1 and type:
+
+```
+npx @grafana/toolkit plugin:create my-plugin
+```
+
+select `Backend Datasource Plugin`
+
+```
+cd my-plugin
+```
+
+To build the plugin
+```
+yarn install
+yarn build
+mage -v buildAll
+```
+
+{{% /tutorials/step %}}
+{{% tutorials/step duration="1" title="Anatomy of a backend plugin" %}}
+
+The folders and files used to build the backend for the data source are
+
+|file/folder| description |
+|-----------|-------------|
+| `Magefile.go` | It’s not a requirement to use mage build files but we strongly recommend using that so that you can use the build steps provided in the plugin SDK. |
+| `/src/plugins.json` | A JSON file describing the backend plugin |
+| `/pkg/plugin.go` | Starting point of the plugin binary. We suggest that you keep this small and have all data source code in another package |
+| `/pkg/datasource` | The data source implementation in the plugin. |
+
+#### plugin.json
+When building a backend plugin these fields are important.
+
+| field| description |
+|-----------|-------------|
+| backend | should be set to `true` for backend plugins. This tells Grafana that it should start a binary when loading the plugin. |
+| executable | is the name of the executable that grafana expects to start |
+| alerting | Should be set to true if your backend datasource supports alerting |
+
+#### /pkg/plugins.go
+
+This is file where you provide the backend SDK with handler functions by calling `backend.Serve({})`. <!-- TODO update serve function with new PR is merged -->
+In this tutorial we are building a backend for a datasource so we will provide an implementation of the `backend.QueryDataHandler` interface.
+
+More about that in the next step!
+
+{{% /tutorials/step %}}
+{{% tutorials/step duration="1" title="Manage data source configuration" %}}
+
+explain life cycle management for data sources.
+
+{{% /tutorials/step %}}
+{{% tutorials/step duration="2" title="Data source backend plugins" %}}
+
+Open the file `/pkg/datasource/sample-datasource.go` and you will see the `DatasourceInstance` struct which implements the `backend.QueryDataHandler` interface.
+The `QueryData` function on this struct is where the data fetching happens for data source plugin.
+
+Each request contains multiple queries to reduce traffic between Grafana and plugins.
+So you need to loop over the slice of queries, process each query and return the results of all queries.
+
+In the tutorial we have extract a function named `query` to take care of each query model.
+Since each plugin have their own unique query model, Grafana sends it to the backend as JSON. Therefore the plugin needs
+to Unmarshal the query model into something easier to work with.
+
+As you can see the sample only returning countries. Try to extend the plugin to return other types of data.
+
+{{% /tutorials/step %}}
+{{% tutorials/step duration="1" title="Add support for health checks" %}}
+
+Implementing the health check handler allows Grafana to verify that a data source have been configured correctly.
+After a user have created a new datasource in Grafanas UI she can click the **Test** to verify that it works as expected.
+
+In this sample datasource there is a 50/50% chance that the health check is successful. Make sure to return good error messages to
+the users, informing them about what is miss configured in the data source.
+
+Open `/pkg/datasource/sample-datasource.go` and navigate to the `CheckHealth` function to see how the health check for this sample plugin is implemented.
+
+<!--
+{{% /tutorials/step %}}
+{{% tutorials/step duration="1" title="Add support for resource request" %}}
+
+what is resource requests?
+# TODO: Last add this later once the other parts are in better shape.
+
+-->
+
+{{% /tutorials/step %}}
+{{% tutorials/step title="Congratulations" %}}
+
+Congratulations, you made it to the end of this tutorial!
+
+{{% /tutorials/step %}}

--- a/content/tutorials/build-a-data-source-backend-plugin.md
+++ b/content/tutorials/build-a-data-source-backend-plugin.md
@@ -66,8 +66,7 @@ The folders and files used to build the backend for the data source are
 | ------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `Magefile.go`       | It’s not a requirement to use mage build files, but we strongly recommend using it so that you can use the build steps provided in the plugin SDK. |
 | `/src/plugins.json` | A JSON file describing the backend plugin                                                                                                          |
-| `/pkg/plugin.go`    | Starting point of the plugin binary. We suggest that you keep this small and have all data source code in another package                          |
-| `/pkg/datasource`   | The data source implementation in the plugin.                                                                                                      |
+| `/pkg/main.go`      | Starting point of the plugin binary.                                                                                                               |
 
 #### plugin.json
 
@@ -79,12 +78,7 @@ When building a backend plugin these fields are important:
 | executable | This is the name of the executable that Grafana expects to start.                                                      |
 | alerting   | Should be set to true if your backend datasource supports alerting.                                                    |
 
-#### /pkg/plugins.go
-
-This is the file where you provide the backend SDK with handler functions by calling `backend.Serve({})`. <!-- TODO update serve function with new PR is merged -->
-In this tutorial we are building a backend for a datasource, so we will provide an example implementation of the `backend.QueryDataHandler` interface.
-
-More about that in the next step!
+In the next step we will look at the query endpoint!
 
 {{< /tutorials/step >}}
 {{< tutorials/step duration="2" title="Implement data queries" >}}

--- a/content/tutorials/build-a-data-source-backend-plugin.md
+++ b/content/tutorials/build-a-data-source-backend-plugin.md
@@ -50,6 +50,7 @@ cd my-plugin
 ```
 
 To build the plugin
+
 ```
 yarn install
 yarn build
@@ -62,17 +63,18 @@ mage -v buildAll
 The folders and files used to build the backend for the data source are
 
 | file/folder         | description                                                                                                                                         |
-|---------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `Magefile.go`       | It’s not a requirement to use mage build files but we strongly recommend using that so that you can use the build steps provided in the plugin SDK. |
 | `/src/plugins.json` | A JSON file describing the backend plugin                                                                                                           |
 | `/pkg/plugin.go`    | Starting point of the plugin binary. We suggest that you keep this small and have all data source code in another package                           |
 | `/pkg/datasource`   | The data source implementation in the plugin.                                                                                                       |
 
 #### plugin.json
+
 When building a backend plugin these fields are important.
 
 | field      | description                                                                                                            |
-|------------|------------------------------------------------------------------------------------------------------------------------|
+| ---------- | ---------------------------------------------------------------------------------------------------------------------- |
 | backend    | should be set to `true` for backend plugins. This tells Grafana that it should start a binary when loading the plugin. |
 | executable | is the name of the executable that grafana expects to start                                                            |
 | alerting   | Should be set to true if your backend datasource supports alerting                                                     |
@@ -99,10 +101,11 @@ Each request contains multiple queries to reduce traffic between Grafana and plu
 So you need to loop over the slice of queries, process each query and return the results of all queries.
 
 In the tutorial we have extract a function named `query` to take care of each query model.
-Since each plugin have their own unique query model, Grafana sends it to the backend as JSON. Therefore the plugin needs
+Since each plugin have their own unique query model, Grafana sends it to the backend plugin as JSON. Therefore the plugin needs
 to Unmarshal the query model into something easier to work with.
 
-As you can see the sample only returning countries. Try to extend the plugin to return other types of data.
+As you can see the sample only returns static numbers. Try to extend the plugin to return other types of data.
+You can read more about how to (build data frames in our docs)[https://grafana.com/docs/grafana/latest/plugins/developing/dataframes].
 
 {{< /tutorials/step >}}
 {{< tutorials/step duration="1" title="Add support for health checks" >}}

--- a/content/tutorials/build-a-data-source-backend-plugin.md
+++ b/content/tutorials/build-a-data-source-backend-plugin.md
@@ -52,9 +52,9 @@ cd my-plugin
 To build the plugin
 
 ```
-yarn install
-yarn build
-mage -v buildAll
+yarn install --pure-lockfile
+ yarn build
+ mage -v buildAll
 ```
 
 {{< /tutorials/step >}}

--- a/content/tutorials/build-a-data-source-backend-plugin.md
+++ b/content/tutorials/build-a-data-source-backend-plugin.md
@@ -28,7 +28,7 @@ In this tutorial, you'll:
 - [Mage](https://magefile.org/)
 
 {{< /tutorials/step >}}
-{{< tutorials/step duration="1" title="Setup Your Environment" >}}
+{{< tutorials/step duration="1" title="Setup your environment" >}}
 
 {{< tutorials/shared "set-up-environment" >}}
 
@@ -58,7 +58,7 @@ yarn install --pure-lockfile
 ```
 
 {{< /tutorials/step >}}
-{{< tutorials/step duration="1" title="Anatomy of a Backend Plugin" >}}
+{{< tutorials/step duration="1" title="Anatomy of a backend plugin" >}}
 
 The folders and files used to build the backend for the data source are
 
@@ -97,7 +97,7 @@ As you can see the sample only returns static numbers. Try to extend the plugin 
 You can read more about how to [build data frames in our docs](https://grafana.com/docs/grafana/latest/plugins/developing/dataframes).
 
 {{< /tutorials/step >}}
-{{< tutorials/step duration="1" title="Add Support for Health Checks" >}}
+{{< tutorials/step duration="1" title="Add support for health checks" >}}
 
 Implementing the health check handler allows Grafana to verify that a data source has been configured correctly.
 After a user has created a new datasource in Grafana's UI, she can click the **Test** to verify that it works as expected.

--- a/content/tutorials/build-a-data-source-backend-plugin.md
+++ b/content/tutorials/build-a-data-source-backend-plugin.md
@@ -35,8 +35,6 @@ In this tutorial, you'll:
 {{% /tutorials/step %}}
 {{% tutorials/step duration="1" title="Create a new plugin" %}}
 
-<!-- {{< tutorials/shared "create-plugin" >}} -->
-
 To build a backend for your data source plugin grafana requires binary that Grafana can execute when it loads plugin during start-up. In this guide, we will build a binary using our backend plugin SDK in Go.
 
 The easiest way to get started is to clone one of our test data datasources. Navigate to the plugin folder that you configured in step 1 and type:
@@ -45,7 +43,7 @@ The easiest way to get started is to clone one of our test data datasources. Nav
 npx @grafana/toolkit plugin:create my-plugin
 ```
 
-select `Backend Datasource Plugin`
+select `Backend Datasource Plugin` and follow the rest of the guide.
 
 ```
 cd my-plugin

--- a/content/tutorials/build-a-data-source-backend-plugin.md
+++ b/content/tutorials/build-a-data-source-backend-plugin.md
@@ -28,7 +28,7 @@ In this tutorial, you'll:
 - [Mage](https://magefile.org/)
 
 {{< /tutorials/step >}}
-{{< tutorials/step duration="1" title="Set up your environment" >}}
+{{< tutorials/step duration="1" title="Setup Your Environment" >}}
 
 {{< tutorials/shared "set-up-environment" >}}
 

--- a/content/tutorials/build-a-data-source-backend-plugin.md
+++ b/content/tutorials/build-a-data-source-backend-plugin.md
@@ -58,7 +58,7 @@ yarn install --pure-lockfile
 ```
 
 {{< /tutorials/step >}}
-{{< tutorials/step duration="1" title="Anatomy of a backend plugin" >}}
+{{< tutorials/step duration="1" title="Anatomy of a Backend Plugin" >}}
 
 The folders and files used to build the backend for the data source are
 

--- a/content/tutorials/build-a-data-source-backend-plugin.md
+++ b/content/tutorials/build-a-data-source-backend-plugin.md
@@ -10,7 +10,7 @@ Feedback Link: https://github.com/grafana/tutorials/issues/new
 weight: 70
 ---
 
-{{% tutorials/step duration="1" title="Introduction" %}}
+{{< tutorials/step duration="1" title="Introduction" >}}
 
 Grafana supports a wide range of data sources, including Prometheus, MySQL, and even Datadog. There's a good chance you can already visualize metrics from the systems you have set up. In some cases, though, you already have an in-house metrics solution that you’d like to add to your Grafana dashboards. This tutorial teaches you to build a support for your data source.
 
@@ -27,13 +27,13 @@ In this tutorial, you'll:
 - Go 1.14+
 - [Mage](https://magefile.org/)
 
-{{% /tutorials/step %}}
-{{% tutorials/step duration="1" title="Set up your environment" %}}
+{{< /tutorials/step >}}
+{{< tutorials/step duration="1" title="Set up your environment" >}}
 
 {{< tutorials/shared "set-up-environment" >}}
 
-{{% /tutorials/step %}}
-{{% tutorials/step duration="1" title="Create a new plugin" %}}
+{{< /tutorials/step >}}
+{{< tutorials/step duration="1" title="Create a new plugin" >}}
 
 To build a backend for your data source plugin grafana requires binary that Grafana can execute when it loads plugin during start-up. In this guide, we will build a binary using our backend plugin SDK in Go.
 
@@ -56,26 +56,26 @@ yarn build
 mage -v buildAll
 ```
 
-{{% /tutorials/step %}}
-{{% tutorials/step duration="1" title="Anatomy of a backend plugin" %}}
+{{< /tutorials/step >}}
+{{< tutorials/step duration="1" title="Anatomy of a backend plugin" >}}
 
 The folders and files used to build the backend for the data source are
 
-|file/folder| description |
-|-----------|-------------|
-| `Magefile.go` | It’s not a requirement to use mage build files but we strongly recommend using that so that you can use the build steps provided in the plugin SDK. |
-| `/src/plugins.json` | A JSON file describing the backend plugin |
-| `/pkg/plugin.go` | Starting point of the plugin binary. We suggest that you keep this small and have all data source code in another package |
-| `/pkg/datasource` | The data source implementation in the plugin. |
+| file/folder         | description                                                                                                                                         |
+|---------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| `Magefile.go`       | It’s not a requirement to use mage build files but we strongly recommend using that so that you can use the build steps provided in the plugin SDK. |
+| `/src/plugins.json` | A JSON file describing the backend plugin                                                                                                           |
+| `/pkg/plugin.go`    | Starting point of the plugin binary. We suggest that you keep this small and have all data source code in another package                           |
+| `/pkg/datasource`   | The data source implementation in the plugin.                                                                                                       |
 
 #### plugin.json
 When building a backend plugin these fields are important.
 
-| field| description |
-|-----------|-------------|
-| backend | should be set to `true` for backend plugins. This tells Grafana that it should start a binary when loading the plugin. |
-| executable | is the name of the executable that grafana expects to start |
-| alerting | Should be set to true if your backend datasource supports alerting |
+| field      | description                                                                                                            |
+|------------|------------------------------------------------------------------------------------------------------------------------|
+| backend    | should be set to `true` for backend plugins. This tells Grafana that it should start a binary when loading the plugin. |
+| executable | is the name of the executable that grafana expects to start                                                            |
+| alerting   | Should be set to true if your backend datasource supports alerting                                                     |
 
 #### /pkg/plugins.go
 
@@ -84,13 +84,13 @@ In this tutorial we are building a backend for a datasource so we will provide a
 
 More about that in the next step!
 
-{{% /tutorials/step %}}
-{{% tutorials/step duration="1" title="Manage data source configuration" %}}
+{{< /tutorials/step >}}
+{{< tutorials/step duration="1" title="Manage data source configuration" >}}
 
 explain life cycle management for data sources.
 
-{{% /tutorials/step %}}
-{{% tutorials/step duration="2" title="Data source backend plugins" %}}
+{{< /tutorials/step >}}
+{{< tutorials/step duration="2" title="Data source backend plugins" >}}
 
 Open the file `/pkg/datasource/sample-datasource.go` and you will see the `DatasourceInstance` struct which implements the `backend.QueryDataHandler` interface.
 The `QueryData` function on this struct is where the data fetching happens for data source plugin.
@@ -104,8 +104,8 @@ to Unmarshal the query model into something easier to work with.
 
 As you can see the sample only returning countries. Try to extend the plugin to return other types of data.
 
-{{% /tutorials/step %}}
-{{% tutorials/step duration="1" title="Add support for health checks" %}}
+{{< /tutorials/step >}}
+{{< tutorials/step duration="1" title="Add support for health checks" >}}
 
 Implementing the health check handler allows Grafana to verify that a data source have been configured correctly.
 After a user have created a new datasource in Grafanas UI she can click the **Test** to verify that it works as expected.
@@ -115,18 +115,9 @@ the users, informing them about what is miss configured in the data source.
 
 Open `/pkg/datasource/sample-datasource.go` and navigate to the `CheckHealth` function to see how the health check for this sample plugin is implemented.
 
-<!--
-{{% /tutorials/step %}}
-{{% tutorials/step duration="1" title="Add support for resource request" %}}
-
-what is resource requests?
-# TODO: Last add this later once the other parts are in better shape.
-
--->
-
-{{% /tutorials/step %}}
-{{% tutorials/step title="Congratulations" %}}
+{{< /tutorials/step >}}
+{{< tutorials/step title="Congratulations" >}}
 
 Congratulations, you made it to the end of this tutorial!
 
-{{% /tutorials/step %}}
+{{< /tutorials/step >}}

--- a/content/tutorials/build-a-data-source-backend-plugin.md
+++ b/content/tutorials/build-a-data-source-backend-plugin.md
@@ -35,7 +35,7 @@ In this tutorial, you'll:
 {{< /tutorials/step >}}
 {{< tutorials/step duration="1" title="Create a new plugin" >}}
 
-To build a backend for your data source plugin grafana requires binary that Grafana can execute when it loads plugin during start-up. In this guide, we will build a binary using our backend plugin SDK in Go.
+To build a backend for your data source plugin, Grafana requires a binary that it can execute when it loads the plugin during start-up. In this guide, we will build a binary using our backend plugin SDK in Go.
 
 The easiest way to get started is to clone one of our test data datasources. Navigate to the plugin folder that you configured in step 1 and type:
 


### PR DESCRIPTION
Some work on this. 

@marcusolsson I got stuck thinking about at what level we should create fake data. I wonder if it would make sense to use the same fake scenario for the frontend datasource and then reuse the same scenario in the backend. I feel like the backend tutorial needs to include some code for generating different kinds of data frames. WDYT?