### PR TITLE
fix location conflict with js/css cache policy

### DIFF
--- a/content/tutorials/run-grafana-behind-a-proxy.md
+++ b/content/tutorials/run-grafana-behind-a-proxy.md
@@ -63,7 +63,7 @@ server {
 - Reload the NGINX configuration.
 - Navigate to port 80 on the machine NGINX is running on. You're greeted by the Grafana login page.
 
-To configure NGINX to serve Grafana under a _sub path_, update the `location` block:
+To configure NGINX to serve Grafana under a _sub path_, update the `location` block, make sure this block is the first `location` block:
 
 ```nginx
 server {
@@ -71,7 +71,7 @@ server {
   root /usr/share/nginx/www;
   index index.html index.htm;
 
-  location /grafana/ {
+  location ~/grafana/ {
    proxy_pass http://localhost:3000/;
   }
 }


### PR DESCRIPTION
with this location, js/css will be 404
```
location ~ .*\.(js|css|woff)?$ {
        expires 30d;
    }
```
because `location ~` has higher priority over `location /grafana/`

[Related issue](https://github.com/grafana/tutorials/issues/83)