### PR TITLE
Add troubleshooting section into data source backend plugin tutorial

### DIFF
--- a/content/tutorials/build-a-data-source-backend-plugin.md
+++ b/content/tutorials/build-a-data-source-backend-plugin.md
@@ -91,7 +91,7 @@ You now have a new data source instance of your plugin that is ready to use in a
 
 ### Troubleshooting
 
-#### Does the list of available data sources not contain your plugin?
+#### Grafana doesn't load my plugin
 
 As stated on the [plugin signature verification documentation](https://grafana.com/docs/grafana/latest/plugins/plugin-signature-verification/#backend-plugins):
 *if a backend plugin is not signed, then Grafana will not load or start it*. So, in order to get your data source backend plugin listed, **you need to

--- a/content/tutorials/build-a-data-source-backend-plugin.md
+++ b/content/tutorials/build-a-data-source-backend-plugin.md
@@ -89,6 +89,14 @@ You now have a new data source instance of your plugin that is ready to use in a
 1. A line graph is rendered with one series consisting of two data points.
 1. Save the dashboard.
 
+### Troubleshooting
+
+#### Does the list of available data sources not contain your plugin?
+
+As stated on the [plugin signature verification documentation](https://grafana.com/docs/grafana/latest/plugins/plugin-signature-verification/#backend-plugins):
+*if a backend plugin is not signed, then Grafana will not load or start it*. So, in order to get your data source backend plugin listed, **you need to
+[allow unsigned plugins](https://grafana.com/docs/grafana/latest/plugins/plugin-signature-verification/#allow-unsigned-plugins).**
+
 {{< /tutorials/step >}}
 {{< tutorials/step title="Anatomy of a backend plugin" >}}
 

--- a/content/tutorials/build-a-data-source-backend-plugin.md
+++ b/content/tutorials/build-a-data-source-backend-plugin.md
@@ -93,9 +93,9 @@ You now have a new data source instance of your plugin that is ready to use in a
 
 #### Grafana doesn't load my plugin
 
-As stated on the [plugin signature verification documentation](https://grafana.com/docs/grafana/latest/plugins/plugin-signature-verification/#backend-plugins):
-*if a backend plugin is not signed, then Grafana will not load or start it*. So, in order to get your data source backend plugin listed, **you need to
-[allow unsigned plugins](https://grafana.com/docs/grafana/latest/plugins/plugin-signature-verification/#allow-unsigned-plugins).**
+By default, Grafana requires backend plugins to be signed. To load unsigned backend plugins, you need to
+configure Grafana to [allow unsigned plugins](https://grafana.com/docs/grafana/latest/plugins/plugin-signature-verification/#allow-unsigned-plugins).
+For more information, refer to [Plugin signature verification](https://grafana.com/docs/grafana/latest/plugins/plugin-signature-verification/#backend-plugins).
 
 {{< /tutorials/step >}}
 {{< tutorials/step title="Anatomy of a backend plugin" >}}


### PR DESCRIPTION
**What this PR does / why we need it**:

- Adds mention to plugin signing documentation and its related configuration in order to improve the developer experience. Otherwise, if you arrive to that step without being aware of plugin signing you have a weird feeling because the situation is a bit messy (you don't see your plugin listed).

**Special notes for your reviewer**:

- I'd really appreciate feedback especially because I'm still improving my English writing skills.

Thanks!!!