### PR TITLE
Create CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,15 @@
+# Lines starting with '#' are comments.
+# Each line is a file pattern followed by one or more owners.
+
+# More details are here: https://help.github.com/articles/about-codeowners/
+
+# The '*' pattern is global owners.
+
+# Order is important. The last matching pattern has the most precedence.
+# The folders are ordered as follows:
+
+# In each subsection folders are ordered first by depth, then alphabetically.
+# This should make it easy to add new rules without breaking existing ones.
+
+# Documentation owner: TBD
+/content/ @marcusolsson @grafana/docs-squad

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,5 +11,5 @@
 # In each subsection folders are ordered first by depth, then alphabetically.
 # This should make it easy to add new rules without breaking existing ones.
 
-# Documentation owner: TBD
-/content/ @marcusolsson @grafana/docs-squad
+# Documentation owner: Matthew Helmke
+/content/ @grafana/docs-squad @matthewhelmke


### PR DESCRIPTION
This adds codeowners so that we can have content reviewers without contributors needing to automatically add them.

@grafana/docs-squad - Does anyone want to opt out?

@marcusolsson - Do you want to opt out? Do any community engineers want to opt in?

@matthewhelmke - Do you want to opt in and be a codeowner?