### PR TITLE
Change tutorial endings from Congratulations to Summary

### DIFF
--- a/content/tutorials/build-a-data-source-backend-plugin.md
+++ b/content/tutorials/build-a-data-source-backend-plugin.md
@@ -180,8 +180,8 @@ Open `/pkg/sample-plugin.go`. In this file you'll see that the `SampleDatasource
 1. After some time the alert rule evaluates and transitions into _Alerting_ state.
 
 {{< /tutorials/step >}}
-{{< tutorials/step title="Congratulations" >}}
+{{< tutorials/step title="Summary" >}}
 
-Congratulations, you made it to the end of this tutorial!
+In this tutorial you created a backend for your data source plugin.
 
 {{< /tutorials/step >}}

--- a/content/tutorials/build-a-data-source-plugin.md
+++ b/content/tutorials/build-a-data-source-plugin.md
@@ -370,11 +370,9 @@ The main advantage of `getBackendSrv` is that it proxies requests through the Gr
    ```
 
 {{< /tutorials/step >}}
-{{< tutorials/step title="Congratulations" >}}
+{{< tutorials/step title="Summary" >}}
 
-Congratulations, you made it to the end of this tutorial!
-
-You've built a complete data source plugin for Grafana that uses a query editor to control what data to visualize. You've added a data source option, commonly used to set connection options and more.
+In this tutorial you built a complete data source plugin for Grafana that uses a query editor to control what data to visualize. You've added a data source option, commonly used to set connection options and more.
 
 ### Learn more
 

--- a/content/tutorials/build-a-panel-plugin-with-d3.md
+++ b/content/tutorials/build-a-panel-plugin-with-d3.md
@@ -232,8 +232,8 @@ export const SimplePanel: React.FC<Props> = ({ options, data, width, height }) =
 };
 ```
 {{< /tutorials/step >}}
-{{< tutorials/step title="Congratulations" >}}
+{{< tutorials/step title="Summary" >}}
 
-Congratulations, you made it to the end of this tutorial!
+In this tutorial you built a panel plugin with D3.js.
 
 {{< /tutorials/step >}}

--- a/content/tutorials/build-a-panel-plugin.md
+++ b/content/tutorials/build-a-panel-plugin.md
@@ -1,6 +1,6 @@
 ---
 title: Build a panel plugin
-summary: Learn at how to create a custom visualization for your dashboards.
+summary: Learn how to create a custom visualization for your dashboards.
 id: build-a-panel-plugin
 categories: ["plugins"]
 tags: ["beginner"]
@@ -256,8 +256,8 @@ Let's see how you can retrieve data from a data frame and use it in your visuali
 If you want to know more about data frames, check out our introduction to [Data frames](https://grafana.com/docs/grafana/latest/developers/plugins/data-frames/).
 
 {{% /tutorials/step %}}
-{{< tutorials/step title="Congratulations" >}}
+{{< tutorials/step title="Summary" >}}
 
-Congratulations, you made it to the end of this tutorial!
+In this tutorial you learned how to create a custom visualization for your dashboards.
 
 {{< /tutorials/step >}}

--- a/content/tutorials/build-a-streaming-data-source-plugin.md
+++ b/content/tutorials/build-a-streaming-data-source-plugin.md
@@ -162,8 +162,8 @@ return &backend.PublishStreamResponse{
 ```
 
 {{< /tutorials/step >}}
-{{< tutorials/step title="Congratulations" >}}
+{{< tutorials/step title="Summary" >}}
 
-Congratulations, you made it to the end of this tutorial! Happy streaming!
+In this tutorial you created a backend for your data source plugin with streaming capabilities.
 
 {{< /tutorials/step >}}

--- a/content/tutorials/build-an-app-plugin.md
+++ b/content/tutorials/build-an-app-plugin.md
@@ -211,8 +211,8 @@ If you want to let users know that your app requires an existing plugin, you can
 ```
 
 {{< /tutorials/step >}}
-{{< tutorials/step title="Congratulations" >}}
+{{< tutorials/step title="Summary" >}}
 
-Congratulations, you made it to the end of this tutorial!
+In this tutorial you learned how to create an app plugin.
 
 {{< /tutorials/step >}}

--- a/content/tutorials/create-users-and-teams.md
+++ b/content/tutorials/create-users-and-teams.md
@@ -206,9 +206,7 @@ Graphona has hired a consultant to assist the Marketing team. The consultant sho
 You've created a new user and given them unique permissions to view contents of a folder.
 
 {{< /tutorials/step >}}
-{{< tutorials/step title="Congratulations" >}}
-
-Congratulations, you made it to the end of this tutorial!
+{{< tutorials/step title="Summary" >}}
 
 In this tutorial, you've configured Grafana for an organization:
 

--- a/content/tutorials/grafana-fundamentals.md
+++ b/content/tutorials/grafana-fundamentals.md
@@ -354,9 +354,9 @@ docker-compose down -v
 ```
 
 {{< /tutorials/step >}}
-{{< tutorials/step title="Congratulations" >}}
+{{< tutorials/step title="Summary" >}}
 
-Congratulations, you made it to the end of this tutorial!
+In this tutorial you learned about fundamental features of Grafana.
 
 ### Learn more
 
@@ -367,4 +367,3 @@ Congratulations, you made it to the end of this tutorial!
 - [Notification channels](https://grafana.com/docs/grafana/latest/alerting/notifications/).
 
 {{< /tutorials/step >}}
-

--- a/content/tutorials/install-grafana-on-raspberry-pi.md
+++ b/content/tutorials/install-grafana-on-raspberry-pi.md
@@ -133,9 +133,9 @@ Grafana is now installed, but not yet running. To make sure Grafana starts up ev
 Congratulations! Grafana is now running on your Raspberry Pi. If the Raspberry Pi is ever restarted or turned off, Grafana will start up whenever the machine regains power.
 
 {{< /tutorials/step >}}
-{{< tutorials/step title="Congratulations" >}}
+{{< tutorials/step title="Summary" >}}
 
-Congratulations, you've made it to the end of this tutorial! If you want to use Grafana without having to go through a full installation process, check out [Grafana Cloud](https://grafana.com/products/cloud/), which is designed to get users up and running quickly and easily. Grafana Cloud offers a forever free plan that is genuinely useful for hobbyists, testing, and small teams.
+If you want to use Grafana without having to go through a full installation process, check out [Grafana Cloud](https://grafana.com/products/cloud/), which is designed to get users up and running quickly and easily. Grafana Cloud offers a forever free plan that is genuinely useful for hobbyists, testing, and small teams.
 
 ### Learn more
 

--- a/content/tutorials/provision-dashboards-and-data-sources.md
+++ b/content/tutorials/provision-dashboards-and-data-sources.md
@@ -268,9 +268,9 @@ For more information on how to configure dashboard providers, refer to [Dashboar
 > If you don't specify an `id` in the dashboard definition, then Grafana assigns one during provisioning. You can set the `id` yourself if you want to reference the dashboard from other dashboards. Be careful to not use the same `id` for multiple dashboards, as this will cause a conflict.
 
 {{< /tutorials/step >}}
-{{< tutorials/step title="Congratulations" >}}
+{{< tutorials/step title="Summary" >}}
 
-Congratulations, you made it to the end of this tutorial!
+In this tutorial you learned how you to reuse dashboards and data sources across multiple teams by provisioning Grafana from version-controlled configuration files.
 
 Dashboard definitions can get unwieldly as more panels and configurations are added to them. There are a number of open source tools available to make it easier to manage dashboard definitions:
 

--- a/content/tutorials/run-grafana-behind-a-proxy.md
+++ b/content/tutorials/run-grafana-behind-a-proxy.md
@@ -174,3 +174,8 @@ http:
 ```
 
 {{< /tutorials/step >}}
+{{< tutorials/step title="Summary" >}}
+
+In this tutorial you learned how to run Grafana behind a reverse proxy.
+
+{{< /tutorials/step >}}

--- a/content/tutorials/stream-metrics-from-telegraf-to-grafana.md
+++ b/content/tutorials/stream-metrics-from-telegraf-to-grafana.md
@@ -99,8 +99,8 @@ If you aim for a high-frequency update sending then you may want to use the WebS
 WebSocket avoids running all Grafana HTTP middleware on each request from Telegraf thus reducing Grafana backend CPU usage significantly.
 
 {{< /tutorials/step >}}
-{{< tutorials/step title="Congratulations" >}}
+{{< tutorials/step title="Summary" >}}
 
-Congratulations, you made it to the end of this tutorial! Happy streaming!
+In this tutorial you learned how to use Telegraf to stream live metrics to Grafana.
 
 {{< /tutorials/step >}}


### PR DESCRIPTION
There are a couple tutorials that do not follow the full pattern of all the others. This PR does nothing to fix that.

It does, however, change existing "Congratulations" sections to "Summary" sections with simple content.