### PR TITLE
Avoid using trailing slash in upstream

### DIFF
--- a/content/tutorials/run-grafana-behind-a-proxy.md
+++ b/content/tutorials/run-grafana-behind-a-proxy.md
@@ -70,7 +70,7 @@ server {
   }
 
   # Proxy Grafana Live WebSocket connections.
-  location /api/live {
+  location /api/live/ {
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection $connection_upgrade;
@@ -105,13 +105,15 @@ server {
   root /usr/share/nginx/www;
   index index.html index.htm;
 
-  location /grafana {
+  location /grafana/ {
+    rewrite  ^/grafana/(.*)  /$1 break;
     proxy_set_header Host $http_host; 
     proxy_pass http://grafana;
   }
 
   # Proxy Grafana Live WebSocket connections.
-  location /grafana/api/live {
+  location /grafana/api/live/ {
+    rewrite  ^/grafana/(.*)  /$1 break;
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection $connection_upgrade;


### PR DESCRIPTION
I believe the configuration without using trailing slash is less error-prone. And I think it's more common to not use trailing slash in upstream.

Several issues where having trailing slash in upstream resulted into problems:

* https://github.com/grafana/grafana/issues/18299
* https://github.com/grafana/grafana/issues/36929
* https://github.com/grafana/grafana/issues/13955

The rewrite on sub path is actually optional – since Grafana can trim prefix of URL path before looking for a route. But it seems that rewrite on proxy level makes behaviour explicit.

Also, replaced `/api/live` match to `/api/live/` to avoid matching with sth like `/api/livestream`  