### PR TITLE
Docs: Update references to grafana-toolkit plugin:create to use create-plugin

### DIFF
--- a/content/tutorials/build-a-data-source-backend-plugin.md
+++ b/content/tutorials/build-a-data-source-backend-plugin.md
@@ -43,13 +43,13 @@ In this tutorial, you'll:
 
 To build a backend for your data source plugin, Grafana requires a binary that it can execute when it loads the plugin during start-up. In this guide, we will build a binary using the [Grafana plugin SDK for Go](https://grafana.com/docs/grafana/latest/developers/plugins/backend/grafana-plugin-sdk-for-go/).
 
-The easiest way to get started is to clone one of our test data datasources. Navigate to the plugin folder that you configured in step 1 and type:
+The easiest way to get started is to use the Grafana [create-plugin tool](https://www.npmjs.com/package/@grafana/create-plugin). Navigate to the plugin folder that you configured in step 1 and type:
 
 ```
-npx @grafana/toolkit plugin:create my-plugin
+npx @grafana/create-plugin
 ```
 
-Select **Backend Datasource Plugin** and follow the rest of the steps in the plugin scaffolding command.
+Follow the steps and select **datasource** as your plugin type and answer **yes** when prompted to create a backend for your plugin.
 
 ```bash
 cd my-plugin

--- a/content/tutorials/build-a-streaming-data-source-plugin.md
+++ b/content/tutorials/build-a-streaming-data-source-plugin.md
@@ -42,13 +42,13 @@ In this tutorial, you'll:
 
 To build a backend for your data source plugin, Grafana requires a binary that it can execute when it loads the plugin during start-up. In this guide, we will build a binary using the [Grafana plugin SDK for Go](https://grafana.com/docs/grafana/latest/developers/plugins/backend/grafana-plugin-sdk-for-go/).
 
-The easiest way to get started is to clone one of our test data datasources. Navigate to the plugin folder that you configured in step 1 and type:
+The easiest way to get started is to use the Grafana [create-plugin tool](https://www.npmjs.com/package/@grafana/create-plugin). Navigate to the plugin folder that you configured in step 1 and type:
 
 ```
-npx @grafana/toolkit plugin:create my-plugin
+npx @grafana/create-plugin
 ```
 
-Select **Backend Datasource Plugin** and follow the rest of the steps in the plugin scaffolding command.
+Follow the steps and select **datasource** as your plugin type and answer **yes** when prompted to create a backend for your plugin.
 
 ```bash
 cd my-plugin

--- a/content/tutorials/build-an-app-plugin.md
+++ b/content/tutorials/build-an-app-plugin.md
@@ -164,12 +164,12 @@ An app plugin can contain panel and data source plugins that get installed along
 In this step, you'll add a data source to your app plugin. You can add panel plugins the same way by changing `datasource` to `panel`.
 
 1. In `src/`, create a new directory called `datasources`.
-1. Create a new data source using Grafana Toolkit in a temporary directory.
+1. Create a new data source using Grafana create-plugin tool in a temporary directory.
 
    ```bash
    mkdir tmp
    cd tmp
-   npx @grafana/toolkit plugin:create my-datasource
+   npx @grafana/create-plugin
    ```
 
 1. Move the `src` directory in the data source plugin to `src/datasources`, and rename it to `my-datasource`.

--- a/content/tutorials/shared/create-plugin.md
+++ b/content/tutorials/shared/create-plugin.md
@@ -2,23 +2,23 @@
 title: Create Plugin
 ---
 
-Tooling for modern web development can be tricky to wrap your head around. While you certainly can write your own webpack configuration, for this guide, you'll be using _grafana-toolkit_.
+Tooling for modern web development can be tricky to wrap your head around. While you certainly can write your own webpack configuration, for this guide, you'll be using grafana create-plugin tool
 
-[grafana-toolkit](https://github.com/grafana/grafana/tree/master/packages/grafana-toolkit) is a CLI application that simplifies Grafana plugin development, so that you can focus on code. The toolkit takes care of building and testing for you.
+Grafana [create-plugin tool](https://www.npmjs.com/package/@grafana/create-plugin) is a CLI application that simplifies Grafana plugin development, so that you can focus on code. The tool scaffolds a starter plugin and all the required configuration for you.
 
-1. In the plugin directory, create a plugin from template using the `plugin:create` command:
+1. In the plugin directory, create a plugin from template using create-plugin:
 
    ```
-   npx @grafana/toolkit plugin:create my-plugin
+   npx @grafana/create-plugin
    ```
 
-1. Change directory.
+1. Change directory to your newly created plugin:
 
    ```
    cd my-plugin
    ```
 
-1. Download necessary dependencies:
+1. Install the dependencies:
 
    ```
    yarn install


### PR DESCRIPTION
With https://github.com/grafana/grafana/issues/55997 we are moving away the plugin's functionality inside toolkit to https://github.com/grafana/plugin-tools/tree/main/packages/create-plugin

This PR updates the doc's command to scaffold a plugin to create-plugin and avoid [confusion](https://community.grafana.com/t/what-is-the-recommended-way-to-create-grafana-plugin/75315/3) in the community between toolkit, our [plugin-examples](https://github.com/grafana/grafana-plugin-examples/) and the create-plugin tool


- Update build an app plugin doc
- Update build a streaming datasource plugin doc
- Update the create-plugin documentation
- Update the build a data source backend plugin documentation

Partially addresses https://github.com/grafana/grafana/issues/56001 and https://github.com/grafana/plugin-tools/issues/42
